### PR TITLE
port to Linux/FreeBSD/NetBSD, add bootstrap script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 dmake
+dmake_bootstrap
 sunmake
+make.rules
 *.o
 *.core

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PREFIX =	/usr/local
 MANDIR =	man/man1
 
 CXXFLAGS +=	-Iinclude -I/usr/local/include -D_FILE_OFFSET_BITS=64 \
-		-Wno-format -Wno-parentheses -Wno-switch
+		-Wno-format -Wno-parentheses -Wno-switch -Wno-unused-result
 
 PROG =	dmake
 OBJS =	bin/ar.o bin/depvar.o bin/doname.o bin/dosys.o bin/files.o \
@@ -19,7 +19,7 @@ OBJS =	bin/ar.o bin/depvar.o bin/doname.o bin/dosys.o bin/files.o \
 	lib/vroot/vroot.o
 
 all: ${OBJS}
-	${CXX} ${CXXFLAGS} ${LDFLAGS} -o ${PROG} ${OBJS}
+	${CXX} ${CXXFLAGS} ${LDFLAGS} -o ${PROG} ${OBJS} ${LIBS}
 
 ${OBJS}:
 	${CXX} ${CXXFLAGS} -o $@ -c $<

--- a/bin/main.cc
+++ b/bin/main.cc
@@ -339,8 +339,7 @@ getopt(int argc, char *const *argv, const char *optstring)
 /*
  * Included files
  */
-#include <bsd/bsd.h>		/* bsd_signal() */
-
+#include <bsdcompat.h>	/* bsd_signal() */
 
 #include <ctype.h>
 #include <locale.h>		/* setlocale() */

--- a/bin/misc.cc
+++ b/bin/misc.cc
@@ -41,6 +41,7 @@
 /*
  * Included files
  */
+#include <bsdcompat.h>
 #include <errno.h>
 #include <mk/defs.h>
 #include <mksh/macro.h>		/* SETVAR() */

--- a/bin/pmake.cc
+++ b/bin/pmake.cc
@@ -32,12 +32,23 @@
 #include <mksh/misc.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
+#ifdef BSD
 #include <rpc/rpc.h>		/* host2netname(), netname2host() */
+#endif
 #include <unistd.h>
+
+#ifndef MAXHOSTNAMELEN
+#define MAXHOSTNAMELEN 255
+#endif
+#ifndef MAXNETNAMELEN
+#define MAXNETNAMELEN MAXHOSTNAMELEN
+#endif
+
 
 /*
  * Defined macros
@@ -80,8 +91,8 @@ read_make_machines(Name make_machines_name)
 	wchar_t			c;
 	Boolean			default_make_machines;
 	struct hostent		*hp;
-	wchar_t			local_host[MAX_HOSTNAMELEN + 1];
-	char			local_host_mb[MAX_HOSTNAMELEN + 1] = "";
+	wchar_t			local_host[MAXHOSTNAMELEN + 1];
+	char			local_host_mb[MAXHOSTNAMELEN + 1] = "";
 	int			local_host_wslen;
 	wchar_t			full_host[MAXNETNAMELEN + 1];
 	int			full_host_wslen = 0;
@@ -233,10 +244,10 @@ read_make_machines(Name make_machines_name)
 			WCSTOMBS(mbs_buffer, mp);
 			/*
 			 * Print "Ignoring unknown host" if:
-			 * 1) hostname is longer than MAX_HOSTNAMELEN, or
+			 * 1) hostname is longer than MAXHOSTNAMELEN, or
 			 * 2) hostname is unknown
 			 */
-			if ((wcslen(mp) > MAX_HOSTNAMELEN) ||
+			if ((wcslen(mp) > MAXHOSTNAMELEN) ||
 			    ((hp = gethostbyname(mbs_buffer)) == NULL)) {
 				warning(gettext("Ignoring unknown host %s"),
 					mbs_buffer);

--- a/bin/read.cc
+++ b/bin/read.cc
@@ -34,6 +34,7 @@
 /*
  * Included files
  */
+#include <bsdcompat.h>
 #include <alloca.h>		/* alloca() */
 #include <errno.h>		/* errno */
 #include <fcntl.h>		/* fcntl() */

--- a/bin/read2.cc
+++ b/bin/read2.cc
@@ -34,6 +34,7 @@
 /*
  * Included files
  */
+#include <bsdcompat.h>
 #include <mk/defs.h>
 #include <mksh/dosys.h>		/* sh_command2string() */
 #include <mksh/macro.h>		/* expand_value() */

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e
+
+warnings_off="-Wno-format -Wno-parentheses -Wno-switch -Wno-unused-result"
+
+if [ "x$CXX" = "x" ]; then
+    CXX="c++"
+fi
+if [ "x$CXXFLAGS" = "x" ]; then
+    CXXFLAGS="-O2 -Iinclude -I/usr/local/include -D_FILE_OFFSET_BITS=64 $warnings_off"
+fi
+
+# check if we need libbsd for compatibility
+case "$(uname -s)" in
+    NetBSD)
+        LIBS="-lrt $LIBS"
+        ;;
+    *BSD)
+        ;;
+    *)
+        LIBS="-lbsd $LIBS"
+        ;;
+esac
+
+set -x
+
+# clean
+rm -f bin/*.o lib/mksh/*.o lib/vroot/*.o
+
+# compile sources
+for f in bin/*.cc lib/mksh/*.cc lib/vroot/*.cc ; do
+    $CXX $CXXFLAGS -c $f -o ${f}.o
+done
+
+# link binary
+$CXX $LDFLAGS -o dmake_bootstrap bin/*.o lib/mksh/*.o lib/vroot/*.o $LIBS
+
+# copy rules file
+cp -f bin/make.rules.file make.rules
+
+# check if dmake can bootstrap itself
+./dmake_bootstrap clean
+./dmake_bootstrap LIBS="$LIBS"
+
+set +x
+
+echo "dmake successfully bootstrapped itself!"

--- a/include/bsdcompat.h
+++ b/include/bsdcompat.h
@@ -24,12 +24,27 @@
  */
 
 /*
- * bsd/bsd.h: Interface definitions to BSD compatibility functions for SVR4.
+ * bsdcompat.h: Interface definitions to BSD compatibility functions for SVR4.
  */
 
-#ifndef _BSD_BSD_H
-#define _BSD_BSD_H
+#ifndef _BSDCOMPAT_H
+#define _BSDCOMPAT_H
+
+#include <sys/param.h>  /* defines 'BSD' on *BSD systems */
+#ifndef BSD
+#include <bsd/stdlib.h>  /* libbsd getprogname() */
+#endif
 
 #include <signal.h>
 
+/*
+ * Needed on Linux (GLibc) and FreeBSD.
+ * On Linux using bsd_signal works with C files but in C++ it fails.
+ * Even when the prototypes are declared manually the linker will sill
+ * somehow fail.
+ */
+#if defined(__GLIBC__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#define bsd_signal signal
 #endif
+
+#endif //!_BSDCOMPAT_H

--- a/lib/mksh/misc.cc
+++ b/lib/mksh/misc.cc
@@ -40,7 +40,7 @@
 /*
  * Included files
  */
-#include <bsd/bsd.h>		/* bsd_signal() */
+#include <bsdcompat.h>	/* bsd_signal() */
 #include <mksh/i18n.h>		/* get_char_semantics_value() */
 #include <mksh/misc.h>
 #include <stdarg.h>		/* va_list, va_start(), va_end() */


### PR DESCRIPTION
Tested on recent versions of Ubuntu, FreeBSD, NetBSD and OpenBSD.
A boostrap script was added because the Makefile is incompatible with GNU make and because that's commonly done with source packages of make tools.
I renamed `bsd/bsd.h` to avoid potential interference with libbsd headers.